### PR TITLE
Add CPP preprocessors for Servant 0.12 and 0.13

### DIFF
--- a/hw-kafka-avro.cabal
+++ b/hw-kafka-avro.cabal
@@ -41,6 +41,7 @@ library
                        semigroups,
                        servant,
                        servant-client,
+                       servant-client-core,
                        tagged,
                        text,
                        transformers,


### PR DESCRIPTION
Hit these issues when pulling in `hw-kafka-avro` from a (Nix) project depending on Servant 0.12.x. I am unsure if I should do anything in the Stack files to account for this, if so please let me know!