### PR TITLE
Fix Travis, resolves #12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,6 @@ matrix:
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [libgmp-dev]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1"
-    addons: {apt: {packages: [libgmp-dev]}}
-
   - env: BUILD=stack ARGS="--resolver lts-8"
     compiler: ": #stack 8.0.8"
     addons: {apt: {packages: [libgmp-dev]}}
@@ -63,10 +59,6 @@ matrix:
 
   - env: BUILD=stack ARGS="--stack-yaml stack-6.yaml"
     compiler: ": #stack 7.10.3 osx"
-    os: osx
-
-  - env: BUILD=stack ARGS="--resolver lts-7"
-    compiler: ": #stack 8.0.1 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver lts-8"

--- a/src/Kafka/Avro/SchemaRegistry.hs
+++ b/src/Kafka/Avro/SchemaRegistry.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase                 #-}
@@ -116,9 +117,11 @@ fromHttpError err f = case err of
   HttpExceptionRequest _ ConnectionTimeout          -> SchemaRegistryConnectError (displayException err)
   HttpExceptionRequest _ ProxyConnectException{}    -> SchemaRegistryConnectError (displayException err)
   HttpExceptionRequest _ ConnectionClosed           -> SchemaRegistryConnectError (displayException err)
-  HttpExceptionRequest _ (InvalidProxySettings _)   -> SchemaRegistryConnectError (displayException err)
   HttpExceptionRequest _ (InvalidDestinationHost _) -> SchemaRegistryConnectError (displayException err)
   HttpExceptionRequest _ TlsNotSupported            -> SchemaRegistryConnectError (displayException err)
+#if MIN_VERSION_http_client(0,5,7)
+  HttpExceptionRequest _ (InvalidProxySettings _)   -> SchemaRegistryConnectError (displayException err)
+#endif
   HttpExceptionRequest _ err'                       -> f err'
 
 ---------------------------------------------------------------------

--- a/stack-6.yaml
+++ b/stack-6.yaml
@@ -8,6 +8,8 @@ extra-deps:
   - avro-0.2.0.0
   - cache-0.1.0.0
   - pure-zlib-0.6
+  - wreq-0.5.2.1
+  - cabal-doctest-1.0.6
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
- guard code blocks with CPP preprocessors
- add appropriate libraries to extra-dependencies in stack-6
- Remove support for LTS-7 which uses an old and pre-revamped version
  of http-client