### PR TITLE
Configuration option to disable auto-registering of schemas

### DIFF
--- a/src/Kafka/Avro/Encode.hs
+++ b/src/Kafka/Avro/Encode.hs
@@ -36,9 +36,7 @@ valueSubject :: Subject -> Subject
 valueSubject (Subject subj) = Subject (subj <> "-value")
 {-# INLINE valueSubject #-}
 
--- | Encodes a provided value as a message key.
---
--- Registers the schema in SchemaRegistry with "<subject>-key" subject.
+-- | Encodes a provided value as a message key with "<subject>-key" subject.
 encodeKey :: (MonadIO m, HasAvroSchema a, ToAvro a)
   => SchemaRegistry
   -> Subject
@@ -47,9 +45,7 @@ encodeKey :: (MonadIO m, HasAvroSchema a, ToAvro a)
 encodeKey sr subj = encode sr (keySubject subj)
 {-# INLINE encodeKey #-}
 
--- | Encodes a provided value as a message key.
---
--- Registers the schema in SchemaRegistry with "<subject>-key" subject.
+-- | Encodes a provided value as a message key with "<subject>-key" subject.
 encodeKeyWithSchema :: (MonadIO m, ToAvro a)
   => SchemaRegistry
   -> Subject
@@ -59,9 +55,7 @@ encodeKeyWithSchema :: (MonadIO m, ToAvro a)
 encodeKeyWithSchema sr subj = encodeWithSchema sr (keySubject subj)
 {-# INLINE encodeKeyWithSchema #-}
 
--- | Encodes a provided value as a message value.
---
--- Registers the schema in SchemaRegistry with "<subject>-value" subject.
+-- | Encodes a provided value as a message value with "<subject>-value" subject.
 encodeValue :: (MonadIO m, HasAvroSchema a, ToAvro a)
   => SchemaRegistry
   -> Subject
@@ -70,9 +64,7 @@ encodeValue :: (MonadIO m, HasAvroSchema a, ToAvro a)
 encodeValue sr subj = encode sr (valueSubject subj)
 {-# INLINE encodeValue #-}
 
--- | Encodes a provided value as a message value.
---
--- Registers the schema in SchemaRegistry with "<subject>-value" subject.
+-- | Encodes a provided value as a message value with "<subject>-value" subject.
 encodeValueWithSchema :: (MonadIO m, ToAvro a)
   => SchemaRegistry
   -> Subject
@@ -91,7 +83,6 @@ encode sr subj a = encodeWithSchema sr subj (schemaOf a) a
 {-# INLINE encode #-}
 
 -- | Encodes a provided value into Avro
--- and registers value's schema in SchemaRegistry.
 encodeWithSchema :: forall a m. (MonadIO m, ToAvro a)
   => SchemaRegistry
   -> Subject


### PR DESCRIPTION
Closes #57.

This PR adds a configuration option to disable auto-registering of schemas, equivalent to confluent's [`auto.register.schemas` configuration](https://docs.confluent.io/platform/current/schema-registry/schema_registry_onprem_tutorial.html#auto-schema-registration).
I've also refactored the `Kafka.Avro.SchemaRegistry` module to allow the addition of new configuration options in the future, without adding a new smart constructor for each configuration.