### PR TITLE
Expose `schemaRegistryWithConfig`

### DIFF
--- a/src/Kafka/Avro/SchemaRegistry.hs
+++ b/src/Kafka/Avro/SchemaRegistry.hs
@@ -9,6 +9,7 @@ module Kafka.Avro.SchemaRegistry
 ( schemaRegistry, loadSchema, sendSchema
 , schemaRegistry_
 , schemaRegistryWithHeaders
+, schemaRegistryWithConfig
 , loadSubjectSchema
 , getGlobalConfig, getSubjectConfig
 , getVersions, isCompatible


### PR DESCRIPTION
This is a follow-up to:

- #58

I had forgotten to export the `schemaRegistryWithConfig` function, which is needed to be able to set the new `cAutoRegisterSchemas` option.